### PR TITLE
Fix Gauge website link in README (use https://gauge.org/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Setup Gauge
 
-This github action allows for installation of the [Gauge CLI](gauge.org) to be used in your actions pipeline.
+This github action allows for installation of the [Gauge CLI](https://gauge.org/) to be used in your actions pipeline.
 
 It has support for Linux, MacOS and Windows runners.
 


### PR DESCRIPTION
Thanks for maintaining this action.

The README linked to `gauge.org` without a scheme, which GitHub rendered as a relative URL under this repository. https://github.com/getgauge/setup-gauge/blob/master/gauge.org (causes 404)

Update the link to `https://gauge.org/` so it points to the official Gauge site.